### PR TITLE
Fix name and handle on PyPA/Nox listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The star symbol under "PR Mentorship Focus area" column means that the mentor di
 | Marcos Pereira   | https://twitter.com/marcospereira    | Any project under Play Framework organization   |
 | Howard Chu   | https://twitter.com/hyc_symas    | Happy to mentor OpenLDAP, LMDB, Monero. Can advise on a bunch of other security-related projects as well e.g. OpenSSL, Cyrus SASL, Heimdal or MIT Kerberos, etc. |
 | Reuben Bond   | https://twitter.com/reubenbond   | Keen to help anyone hoping to contribute to Microsoft Orleans or otherwise :)    |
-| Jason Brown   | https://twitter.com/jasobrown    | Always happy to help people contribute to http://packaging.python.org, http://nox.readthedocs.io, and google-cloud-python |
+| Jon Parrott   | https://twitter.com/jonparrott    | Always happy to help people contribute to http://packaging.python.org, http://nox.readthedocs.io, and google-cloud-python |
 | Raul Raja   | https://twitter.com/raulraja    | I'd love to help folks with their first PRs to http://arrow-kt.io  & http://frees.io    |
 | Steffen Forkmann   | https://twitter.com/sforkmann    | FSProjects/Mechanic https://github.com/fsprojects/Mechanic   |
 | Ed Anderson   | https://twitter.com/edyesed    | *    |


### PR DESCRIPTION
The tweet reply was being credited to Jason Brown, when in reality it was Jon Parrot who tweeted it. :)